### PR TITLE
Clarify Doc for Secondary axis, ad-hoc example

### DIFF
--- a/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/examples/subplots_axes_and_figures/secondary_axis.py
@@ -79,6 +79,17 @@ plt.show()
 # the data, and is derived empirically.  In that case we can set the
 # forward and inverse transforms functions to be linear interpolations from the
 # one data set to the other.
+#
+# .. note ::
+#
+#   In order to properly handle the data margins, the mapping functions 
+#   (`forward` and `inverse` in this example) need to be defined beyond the 
+#   nominal plot limits.
+#
+#   In the specific case of the numpy linear interpolation, `numpy.interp`, 
+#   this condition can be arbitrarily enforced by providing optional kwargs 
+#   `left`, `right` such that values outside the data range are mapped 
+#   well outside the plot limits.
 
 fig, ax = plt.subplots(constrained_layout=True)
 xdata = np.arange(1, 11, 0.4)


### PR DESCRIPTION
## PR Summary

This clarifies that the mapping functions for secondary_axis need to be defined beyond the nominal plot range, which requires special care when doing ad-hoc mappings using interpolation functions.

I've also added a very brief note that at least hints at how to use ad-hoc mapping when defining the interpolation beyond the data range is impractical. I'll be the first to admit it is probably a bit too cryptic as written, but I also didn't want to add a novel.

Addresses #19205

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ N/A] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
